### PR TITLE
Added event listers, modified behavior to restart tracing after cancel/save

### DIFF
--- a/example/geosimulate.js
+++ b/example/geosimulate.js
@@ -15,6 +15,23 @@ instance.addLayer('vector', {
 const opts = {
   simulate: sim.data,
   immediateStart: true,
+  on: {
+    start(ctx) {
+      console.log('start', ctx);
+    },
+    pause(ctx) {
+      console.log('pause', ctx);
+    },
+    resume(ctx) {
+      console.log('resume', ctx);
+    },
+    done(ctx) {
+      console.log('done', ctx);
+    },
+    cancel(ctx) {
+      console.log('cancel', ctx);
+    },
+  },
 };
 const simCtrl = geotraceCtrl(instance.map, opts);
 instance.map.addControl(simCtrl);

--- a/example/geosimulate.js
+++ b/example/geosimulate.js
@@ -15,6 +15,8 @@ instance.addLayer('vector', {
 const opts = {
   simulate: sim.data,
   immediateStart: true,
+  closed: true,
+  recenter: false,
   on: {
     start(ctx) {
       console.log('start', ctx);
@@ -25,8 +27,8 @@ const opts = {
     resume(ctx) {
       console.log('resume', ctx);
     },
-    done(ctx) {
-      console.log('done', ctx);
+    save(ctx) {
+      console.log('save', ctx);
     },
     cancel(ctx) {
       console.log('cancel', ctx);

--- a/example/vite.config.js
+++ b/example/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig({
         '!**/node_modules/farmos-map-geotrace/**',
       ],
     },
+    host: true,
   },
   build: {
     rollupOptions: {


### PR DESCRIPTION
Hi @jgaehring  I've made some revision on the project.

1. Added event listeners for all states cycle.
2. Modified behavior. So, the scenario is make user to restart tracing after cancel or save. In the client side (which will use this lib, for example, SurveyStack), it is easy to process the next step with the generated data anytime on the `save` event or whatever they want.
3. I've added `GeoJSON` format as a property of the `ctx` which is the shared context across all event listeners. We still have to finalize the structure of the context, but I just want you to review if it would be good start. For example, we can add the cleanup helper function to the context in case the user want to move next page on `pause` event.

I am sorry if some comments is missing on the code, let me know!

I would happy to hear from you.